### PR TITLE
remove fastqc fix typo in curated lineages

### DIFF
--- a/service-scripts/App-SARS2Wastewater.pl
+++ b/service-scripts/App-SARS2Wastewater.pl
@@ -1,7 +1,3 @@
-### Before deploying on alpha:
-### update barcodes and curated_linages paths to be a variable?
-###
-
 #
 # App wrapper for the SARS2Waterwater analysis pipeline.
 # This runs snakemake files for the BV-BRC's sars2-onecodex pipeline and Freyja
@@ -145,8 +141,8 @@ sub process_read_input
     my %config_vars;
     # temp
     my $barcodes_path = "$ENV{FD_TOP}usher_barcodes.csv";
-    my $curated_linages_path = "$ENV{FD_TOP}curated_lineages.json";
-    my $lineages_path = "$ENV{FD_TOP}lineages.yml.json";
+    my $curated_lineages_path = "$ENV{FD_TOP}curated_lineages.json";
+    my $lineages_path = "$ENV{FD_TOP}lineages.yml";
 
     my $wf_dir = "$ENV{KB_TOP}/workflows/$ENV{KB_MODULE_DIR}";
     if (! -d $wf_dir)

--- a/workflow/snakefile/freyja_snakefile
+++ b/workflow/snakefile/freyja_snakefile
@@ -54,7 +54,7 @@ workflow_dir = config["workflow_dir"]
 minimum_base_quality_score_val = config["params"]["minimum_base_quality_score"]
 ### freyja demix command variables ###
 barcodes_path = config["barcodes_path"]
-curated_lineages = config["curated_lineages"]
+curated_lineages = config["curated_lineages_path"]
 lineages = config["lineages_path"]
 eps_val = config["params"]["minimum_lineage_abundance"]
 covcut_val = config["params"]["coverage_estimate"]

--- a/workflow/snakefile/freyja_snakefile
+++ b/workflow/snakefile/freyja_snakefile
@@ -55,7 +55,7 @@ minimum_base_quality_score_val = config["params"]["minimum_base_quality_score"]
 ### freyja demix command variables ###
 barcodes_path = config["barcodes_path"]
 curated_lineages = config["curated_lineages"]
-lineages = config["lineages"]
+lineages = config["lineages_path"]
 eps_val = config["params"]["minimum_lineage_abundance"]
 covcut_val = config["params"]["coverage_estimate"]
 depthcutoff_val = config["params"]["minimum_coverage_depth"]

--- a/workflow/snakefile/pe_freyja_snakefile
+++ b/workflow/snakefile/pe_freyja_snakefile
@@ -155,9 +155,9 @@ rule fastqc_zpd_reads:
         mkdir -p {params.fastqc_dir}
         mkdir -p {params.clean_up}
 
-        /opt/patric-common/runtime/bin/fastqc --version
+        fastqc --version
 
-        /opt/patric-common/runtime/bin/fastqc {input.raw_read} \
+        fastqc {input.raw_read} \
         -o {params.fastqc_dir} -q
         """
 
@@ -174,9 +174,9 @@ rule fastqc_unzpd_reads:
         mkdir -p {params.fastqc_dir}
         mkdir -p {params.clean_up}
 
-        /opt/patric-common/runtime/bin/fastqc --version
+        fastqc --version
 
-        /opt/patric-common/runtime/bin/fastqc {input.raw_read} \
+        fastqc {input.raw_read} \
         -o {params.fastqc_dir} -q
         """
 
@@ -195,12 +195,12 @@ rule fastqc_ivar:
         mkdir -p {params.fastqc_dir}
         mkdir -p {params.clean_up}
 
-        /opt/patric-common/runtime/bin/fastqc --version
+        fastqc --version
 
-        /opt/patric-common/runtime/bin/fastqc {input.ivar_bam} \
+        fastqc {input.ivar_bam} \
         -o {params.fastqc_dir} -q
 
-        /opt/patric-common/runtime/bin/fastqc {input.ivar_sorted_bam} \
+        fastqc {input.ivar_sorted_bam} \
         -o {params.fastqc_dir} -q
         """
 

--- a/workflow/snakefile/se_freyja_snakefile
+++ b/workflow/snakefile/se_freyja_snakefile
@@ -149,9 +149,9 @@ rule fastqc_zpd_reads:
         mkdir -p {params.fastqc_dir}
         mkdir -p {params.clean_up}
 
-        /opt/patric-common/runtime/bin/fastqc --version
+        fastqc --version
 
-        /opt/patric-common/runtime/bin/fastqc {input.raw_read} \
+        fastqc {input.raw_read} \
         -o {params.fastqc_dir} -q
         '''
 
@@ -168,9 +168,9 @@ rule fastqc_unzpd_reads:
         mkdir -p {params.fastqc_dir}
         mkdir -p {params.clean_up}
 
-        /opt/patric-common/runtime/bin/fastqc --version
+        fastqc --version
 
-        /opt/patric-common/runtime/bin/fastqc {input.raw_read} \
+        fastqc {input.raw_read} \
         -o {params.fastqc_dir} -q
         '''
 
@@ -189,12 +189,12 @@ rule fastqc_ivar:
         mkdir -p {params.fastqc_dir}
         mkdir -p {params.clean_up}
 
-        /opt/patric-common/runtime/bin/fastqc --version
+        fastqc --version
 
-        /opt/patric-common/runtime/bin/fastqc {input.ivar_bam} \
+        fastqc {input.ivar_bam} \
         -o {params.fastqc_dir} -q
 
-        /opt/patric-common/runtime/bin/fastqc {input.ivar_sorted_bam} \
+        fastqc {input.ivar_sorted_bam} \
         -o {params.fastqc_dir} -q
         '''
 


### PR DESCRIPTION
Hello Bob,
This PR should make the following changes:

### service-scripts/App-SARS2Wastewater.pl
- remove comments at the top of the app-script
- fix curated_linages_path as curated_lineages_path

### workflow/snakefile/freyja_snakefile
- downstream fix curated_linages_path as curated_lineages_path
- update lineages to lineages_path to match config

### workflow/snakefile/pe_freyja_snakefile and workflow/snakefile/se_freyja_snakefile
- remove path from FastQC

:) 
Nicole 