### PR TITLE
Updates to support usher barcodes feather file for freyja version 1.5.1

### DIFF
--- a/workflow/scripts/sample_level_plots.py
+++ b/workflow/scripts/sample_level_plots.py
@@ -123,7 +123,7 @@ def plot_variant_by_samples(df_variants, sample_variant_out):
     barmode='stack',
     title='Variant Abundance by Sample',
     title_font_size=24,
-    xaxis_title='Date',
+    xaxis_title='Sample',
     xaxis_title_font_size=18,
     yaxis_title='Abundance (%)',
     yaxis_title_font_size=18,

--- a/workflow/scripts/time_series_plots.py
+++ b/workflow/scripts/time_series_plots.py
@@ -190,7 +190,7 @@ def lineage_day_plot(df, dates_df, day_lineage_out):
 
     # Round values
     final_df['normalized_avg'].round(3)
-
+    final_df.sort_values(by=['normalized_avg'], inplace=True)
     # Pivot the data to have dates as columns and lineages as rows
     pivot_df = final_df.pivot(index='lineage', columns='date', values='normalized_avg').fillna(0)
 
@@ -343,7 +343,7 @@ def week_lineages_plot(df, dates_df, week_lineage_out):
         barmode='stack',
         title='Lineage Abundance by Week',
         title_font_size=24,
-        xaxis_title='Month',
+        xaxis_title='Epiweek',
         xaxis_title_font_size=18,
         yaxis_title='Abundance (%)',
         yaxis_title_font_size=18,

--- a/workflow/snakefile/freyja_snakefile
+++ b/workflow/snakefile/freyja_snakefile
@@ -122,13 +122,14 @@ rule copy_assembly_images_for_report:
 
         cp {params.assembly_image} {output.assembly_images}
         """
+
 rule freyja_variants:
     input:
         ivar_bam_sorted = "output/{sample}/assembly/{sample}.sorted.bam",
         reference = "output/{sample}/assembly/reference_trimmed.fa",
     params:
         eps = eps_val,
-        freyja_analysis_dir = directory("output/{sample}"),
+        freyja_analysis_dir = directory("output/{sample}/freyja"),
         minimum_base_quality_score = minimum_base_quality_score_val,
         tmp_dir = directory("./tmp/")
     output:

--- a/workflow/snakefile/stats_snakefile
+++ b/workflow/snakefile/stats_snakefile
@@ -1,7 +1,9 @@
+from snakemake.utils import validate
+
 msg = "snakefile command recieved - STATS/Wrap up \n"
 sys.stderr.write(msg)
 
-# ruleorder: freyja_variants > freyja_demix > sample_freyja_vis
+ruleorder: set_aggregate_command > set_freyja_vis > set_timeseries_plot > multiqc
 ### Define wildcards ###
 pe_zpd_samples = glob_wildcards("staging/pe_reads/{sample}_R{read_num}.fastq.gz").sample
 pe_unzpd_samples = glob_wildcards("staging/pe_reads/{sample}_R{read_num}.fastq").sample
@@ -43,13 +45,32 @@ last_barcode_update = config["last_barcode_update"]
 minimum_genome_coverage_val = config["params"]["minimum_genome_coverage"]
 ### freyja plot variables ###
 agg_minimum_lineage_abundance_val = config["params"]["agg_minimum_lineage_abundance"]
-### version long variables ###
-primer_type = config["params"]["primers"]
-primer_version = config["params"]["primer_version"]
 
+# Initialize lists to store primers and primer versions
+primer_type = []
+primer_version = []
+
+# Extract primers and primer versions from paired_end_libs
+for lib in config['params']['paired_end_libs']:
+    primer_type.append(lib.get('primers'))
+    primer_version.append(lib.get('primer_version'))
+
+# Extract primers and primer versions from single_end_libs
+for lib in config['params']['single_end_libs']:
+    primer_type.append(lib.get('primers'))
+    primer_version.append(lib.get('primer_version'))
+
+# Extract primers and primer versions from srr_libs
+for lib in config['params']['srr_libs']:
+    primer_type.append(lib.get('primers'))
+    primer_version.append(lib.get('primer_version'))
+
+# Remove any None values if keys are not present
+primer_type = [p for p in primer_type if p]
+primer_version = [v for v in primer_version if v]
 
 rule_all_list = [
-        "output/multiqc_report.html",
+        "output/SARS2-Wastewater-Analysis-BVBRC_multiqc_report.html",
         "output/version_log.txt",
         "output/freyja_result.tsv",
         "plots/variants_plot.html",
@@ -142,10 +163,10 @@ rule multiqc:
        multiqc_config = os.path.join(workflow_dir, "multiqc_config.yaml"),
     params:
         landing_dir = directory('output'),
-        tmp_multiqc_dir = directory('output/multiqc_data')
+        tmp_multiqc_dir = directory('output/SARS2-Wastewater-Analysis-BVBRC_multiqc_report_data')
     output:
-        'output/multiqc_report.html',
-        cl_multiqc_dir = directory("clean_up/multiqc_data")
+        'output/SARS2-Wastewater-Analysis-BVBRC_SARS2-Wastewater-Analysis-BVBRC_multiqc_report.html',
+        cl_multiqc_dir = directory("clean_up/SARS2-Wastewater-Analysis-BVBRC_multiqc_report_data")
     shell:
         """
         multiqc --version


### PR DESCRIPTION
Freyja version 1.5.1 switches to using a .feather format vs .csv format for the USHER barcodes files.
There are also fixes for the following:
-  x axes that were incorrect after the code refactor
- Parses the primers from each sample rather than at the run level
Thank you! 
Nicole 