### PR TITLE
Update to the wastewater service -  barcode file name and fix the multiqc error

### DIFF
--- a/service-scripts/App-SARS2Wastewater.pl
+++ b/service-scripts/App-SARS2Wastewater.pl
@@ -120,7 +120,7 @@ sub process_read_input
     # temp
 
     my $data_dir = application_backend_dir . "/bvbrc_SARS2Wastewater/current";
-    my $barcodes_path = "$data_dir/usher_barcodes.csv";
+    my $barcodes_path = "$data_dir/usher_barcodes.feather";
     my $curated_lineages_path = "$data_dir/curated_lineages.json";
     my $lineages_path = "$data_dir/lineages.yml";
     my $last_barcode_update = "$data_dir/last_barcode_update.txt";

--- a/workflow/snakefile/stats_snakefile
+++ b/workflow/snakefile/stats_snakefile
@@ -165,7 +165,7 @@ rule multiqc:
         landing_dir = directory('output'),
         tmp_multiqc_dir = directory('output/SARS2-Wastewater-Analysis-BVBRC_multiqc_report_data')
     output:
-        'output/SARS2-Wastewater-Analysis-BVBRC_SARS2-Wastewater-Analysis-BVBRC_multiqc_report.html',
+        'output/SARS2-Wastewater-Analysis-BVBRC_multiqc_report.html',
         cl_multiqc_dir = directory("clean_up/SARS2-Wastewater-Analysis-BVBRC_multiqc_report_data")
     shell:
         """


### PR DESCRIPTION
Hello Bob,
This is a quick change to the wastewater service.
1. An update to the barcode files from .CSV to .FEATHER following the changes made by the Freyja codebase
2. An update to the output filepath for the mutiqc  report - this should remove the raw results from the output directory.

Let me know when this is on alpha and I will test and review.
Nicole 